### PR TITLE
v26.7.1: post-release fixes and e2e test suite

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,190 @@
+# Copyright contributors to the IBM Application Gateway Operator project
+#
+# e2e workflow — runs on every push and pull-request.
+#
+# Jobs
+# ────
+#  unit      Fast: go test ./internal/...  No cluster required.
+#  e2e       Behavioural: kind cluster + operator deploy + make test-e2e
+#            Excludes sidecar tests (separate job below).
+#  e2e-sidecar  Same setup + cert-manager; runs only the sidecar tests.
+#               The webhook requires a valid TLS cert, so cert-manager must
+#               be ready before the operator is deployed.
+
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # Job 1: unit + envtest (no cluster)
+  # ──────────────────────────────────────────────────────────────────────────
+  unit:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run unit tests
+        run: make test
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # Job 2: e2e (all tests except sidecar)
+  # ──────────────────────────────────────────────────────────────────────────
+  e2e:
+    name: E2e tests
+    runs-on: ubuntu-latest
+    needs: unit
+
+    env:
+      # Operator image loaded into kind — never pushed to a registry.
+      IMG: ibm-application-gateway-operator:ci
+      # Operator installation namespace (matches config/default/kustomization.yaml namePrefix).
+      OPERATOR_NS: ibm-application-gateway-operator-system
+      # Namespace where test CRs are created.
+      TEST_NS: iag-e2e
+      # IAG image used in test CRs.  Pods are never actually scheduled to run;
+      # the tests only assert on Kubernetes object state, so any string works.
+      # IAG_ALT_IMAGE must be a different string from IAG_IMAGE so that
+      # TestImageChangeRollingUpdate can observe the controller detecting a change.
+      IAG_IMAGE: fake.invalid/ibm-application-gateway:v1
+      IAG_ALT_IMAGE: fake.invalid/ibm-application-gateway:v2
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # ── Cluster ──────────────────────────────────────────────────────────
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: iag-e2e
+
+      # ── cert-manager ─────────────────────────────────────────────────────
+      # Required by config/certmanager/ (the webhook serving cert).
+      - name: Install cert-manager
+        run: |
+          kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
+          kubectl rollout status deployment/cert-manager         -n cert-manager --timeout=120s
+          kubectl rollout status deployment/cert-manager-webhook -n cert-manager --timeout=120s
+
+      # ── Operator image ───────────────────────────────────────────────────
+      # Generate zz_generated.deepcopy.go before docker build — the file is
+      # not tracked in git (removed in 0633b5a) so the Dockerfile build context
+      # would otherwise be missing DeepCopyObject and fail to compile.
+      - name: Generate code
+        run: make generate
+
+      - name: Build operator image
+        run: docker build -t ${{ env.IMG }} .
+
+      - name: Load operator image into kind
+        run: kind load docker-image ${{ env.IMG }} --name iag-e2e
+
+      # ── Deploy operator ───────────────────────────────────────────────────
+      - name: Deploy operator
+        run: make deploy IMG=${{ env.IMG }}
+
+      - name: Wait for operator to be ready
+        run: |
+          kubectl rollout status deployment/ibm-application-gateway-operator-controller-manager \
+            -n ${{ env.OPERATOR_NS }} --timeout=120s
+
+      # ── NetworkPolicy (OLM gap — apply manually as documented in README) ─
+      - name: Apply egress NetworkPolicy
+        run: |
+          kubectl apply -n ${{ env.OPERATOR_NS }} \
+            -f config/network-policy/operator-egress.yaml
+
+      # ── Run e2e tests (skip sidecar — separate job below) ─────────────────
+      - name: Run e2e tests
+        run: |
+          make test-e2e \
+            NAMESPACE=${{ env.OPERATOR_NS }} \
+            TEST_NAMESPACE=${{ env.TEST_NS }} \
+            IAG_IMAGE=${{ env.IAG_IMAGE }} \
+            IAG_ALT_IMAGE=${{ env.IAG_ALT_IMAGE }} \
+            "RUN=^Test[^S]|^TestS[^i]|^TestSi[^d]"
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # Job 3: sidecar tests
+  # Identical setup to e2e but uses -run=TestSidecar.
+  # Kept separate so a sidecar failure doesn't block the rest of the suite.
+  # ──────────────────────────────────────────────────────────────────────────
+  e2e-sidecar:
+    name: E2e sidecar tests
+    runs-on: ubuntu-latest
+    needs: unit
+
+    env:
+      IMG: ibm-application-gateway-operator:ci
+      OPERATOR_NS: ibm-application-gateway-operator-system
+      TEST_NS: iag-e2e-sidecar
+      IAG_IMAGE: fake.invalid/ibm-application-gateway:ci
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: iag-sidecar
+
+      - name: Install cert-manager
+        run: |
+          kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
+          kubectl rollout status deployment/cert-manager         -n cert-manager --timeout=120s
+          kubectl rollout status deployment/cert-manager-webhook -n cert-manager --timeout=120s
+
+      - name: Generate code
+        run: make generate
+
+      - name: Build operator image
+        run: docker build -t ${{ env.IMG }} .
+
+      - name: Load operator image into kind
+        run: kind load docker-image ${{ env.IMG }} --name iag-sidecar
+
+      - name: Deploy operator
+        run: make deploy IMG=${{ env.IMG }}
+
+      - name: Wait for operator to be ready
+        run: |
+          kubectl rollout status deployment/ibm-application-gateway-operator-controller-manager \
+            -n ${{ env.OPERATOR_NS }} --timeout=120s
+
+      - name: Apply egress NetworkPolicy
+        run: |
+          kubectl apply -n ${{ env.OPERATOR_NS }} \
+            -f config/network-policy/operator-egress.yaml
+
+      - name: Run sidecar e2e tests
+        run: |
+          make test-e2e \
+            NAMESPACE=${{ env.OPERATOR_NS }} \
+            TEST_NAMESPACE=${{ env.TEST_NS }} \
+            IAG_IMAGE=${{ env.IAG_IMAGE }} \
+            IAG_ALT_IMAGE=${{ env.IAG_ALT_IMAGE }} \
+            RUN=TestSidecar

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,37 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test $(shell go list ./... | grep -v /test/e2e) -coverprofile cover.out
+
+# Namespace defaults — override on the command line if needed.
+NAMESPACE      ?= operators
+TEST_NAMESPACE ?= ivia-e2e
+# IAG container image injected into test CRs.  Override with a locally-loaded
+# image when running in CI without access to icr.io.
+IAG_IMAGE     ?= icr.io/ibmappgateway/ibm-application-gateway:latest
+IAG_ALT_IMAGE ?= icr.io/ibmappgateway/ibm-application-gateway:26.6.0
+
+# Optional test filter — e.g. make test-e2e RUN=TestSidecar
+RUN ?=
+
+.PHONY: test-e2e
+test-e2e: ## Run e2e tests against the cluster in ~/.kube/config (operator must already be deployed).
+	go test ./test/e2e/... -v -timeout 20m $(if $(RUN),-run '$(RUN)') \
+	  -args \
+	    -namespace=$(NAMESPACE) \
+	    -test-namespace=$(TEST_NAMESPACE) \
+	    -iag-image=$(IAG_IMAGE) \
+	    -iag-alt-image=$(IAG_ALT_IMAGE)
+
+.PHONY: test-e2e-olm
+test-e2e-olm: ## Install operator via OLM, run e2e tests, then clean up.
+	cd ../ibm-application-gateway-operator-tests && \
+	  BUNDLE_IMG=$(BUNDLE_IMG) NAMESPACE=$(NAMESPACE) TEST_NAMESPACE=$(TEST_NAMESPACE) \
+	  ./01-install.sh
+	$(MAKE) test-e2e
+	cd ../ibm-application-gateway-operator-tests && \
+	  NAMESPACE=$(NAMESPACE) TEST_NAMESPACE=$(TEST_NAMESPACE) \
+	  ./05-cleanup.sh
 
 ##@ Build
 
@@ -180,8 +210,9 @@ CSV_FILE = config/manifests/bases/ibm-application-gateway-operator.clusterservic
 
 .PHONY: bundle
 bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
-	operator-sdk generate kustomize manifests -q 
-	sed -i '/      version: v1/ r $(CSV_FILE).annotations' $(CSV_FILE)
+	operator-sdk generate kustomize manifests -q
+	sed -i 's/displayName: IBMApplication Gateway/displayName: IBM Application Gateway/' $(CSV_FILE)
+	grep -q 'resources:' $(CSV_FILE) || sed -i '/      version: v1/ r $(CSV_FILE).annotations' $(CSV_FILE)
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | sed "s|0000.0000.0000|$(SEMANTIC_VERSION)|g" | sed "s|--version--|$(VERSION)|g" | sed "s|--date--|`date`|g" | operator-sdk generate bundle -q --overwrite --version $(SEMANTIC_VERSION) $(BUNDLE_METADATA_OPTS)
 	echo "  com.redhat.openshift.versions: \"v4.6\"" >> bundle/metadata/annotations.yaml

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
     + [Custom Resource Model](#custom-resource-model)
   * [Security Configuration](#security-configuration)
     + [Restricting Outbound URL Hosts](#restricting-outbound-url-hosts)
+    + [Egress Network Policy](#egress-network-policy)
   * [Installation](#installation)
     + [RedHat OpenShift Environment](#redhat-openshift-environment)
       - [Procedure](#procedure)
@@ -119,6 +120,24 @@ The flag defaults to empty (all HTTPS hosts permitted). Upgrading from a previou
 without setting the flag preserves existing behaviour — no existing CRs will break. The
 startup warning serves as a persistent reminder to configure the flag.
 
+### Egress Network Policy
+
+A `NetworkPolicy` is provided that restricts egress from the operator pod to only what is
+required:
+
+| Destination | Port | Purpose |
+|---|---|---|
+| Any | UDP/TCP 53 | DNS resolution |
+| `kube-system` namespace | TCP 443 | Kubernetes API server |
+| `0.0.0.0/0` except `169.254.0.0/16` | TCP 443 | Web config and OIDC endpoints |
+
+The link-local range (`169.254.0.0/16`) is explicitly blocked to prevent access to cloud
+instance metadata services (AWS IMDSv1, IBM Cloud, Azure IMDS, GCP metadata).
+
+When installing with `kubectl` or kustomize the policy is applied automatically as part of
+the standard manifests. When installing via OLM or OperatorHub, the policy must be applied
+manually after installation — see the relevant procedure below.
+
 ---
 
 ## Installation
@@ -170,6 +189,15 @@ spec:
 kubectl logs -n ibm-application-gateway-operator-system \
   deployment/ibm-application-gateway-operator-controller-manager | grep -i "allowed-url-hosts"
 # Expected output: "Outbound URL host allowlist configured" hosts=[...]
+```
+
+7. **Apply the egress NetworkPolicy.** OLM does not support NetworkPolicy objects in bundle
+   manifests, so the policy must be applied separately. Replace `<namespace>` with the
+   namespace the operator was installed into (e.g. `ibm-application-gateway-operator-system`):
+
+```shell
+kubectl apply -n <namespace> -f \
+  https://raw.githubusercontent.com/IBM-Security/ibm-application-gateway-operator/master/config/network-policy/operator-egress.yaml
 ```
 
 At this point the Operator Lifecycle Manager has been installed into the Kubernetes cluster, the IBM Application Gateway operator has been deployed and a subscription has been created that will monitor for any updates to the operator in the RedHat Operator Catalog. The IBM Application Gateway operator is now operational and any subsequent resources which are created of the kind `IBMApplicationGateway`, or deployments with the required sidecar annotations, will result in the operator being invoked to manage the deployment.
@@ -226,6 +254,15 @@ spec:
 kubectl logs -n operators \
   deployment/ibm-application-gateway-operator-controller-manager | grep -i "allowed-url-hosts"
 # Expected output: "Outbound URL host allowlist configured" hosts=[...]
+```
+
+5. **Apply the egress NetworkPolicy.** OLM does not support NetworkPolicy objects in bundle
+   manifests, so the policy must be applied separately. Replace `<namespace>` with the
+   namespace the operator was installed into (e.g. `operators`):
+
+```shell
+kubectl apply -n <namespace> -f \
+  https://raw.githubusercontent.com/IBM-Security/ibm-application-gateway-operator/master/config/network-policy/operator-egress.yaml
 ```
 
 At this point the Operator Lifecycle Manager has been installed into the Kubernetes cluster, the IBM Application Gateway operator has been deployed and a subscription has been created that will monitor for any updates to the operator on OperatorHub.io. The IBM Application Gateway operator is now operational and any subsequent resources which are created of the kind `IBMApplicationGateway`, or deployments with the required sidecar annotations, will result in the operator being invoked to manage the deployment.
@@ -451,7 +488,7 @@ spec:
   replicas: 3
   deployment:
     serviceAccountName: ibm-application-gateway
-    image: icr.io/ibmappgateway/ibm-application-gateway:26.03
+    image: icr.io/ibmappgateway/ibm-application-gateway:26.06
     imagePullPolicy: IfNotPresent 
   configuration:
     - type: configmap
@@ -987,7 +1024,7 @@ Deployment annotations define how the IBM Application Gateway sidecar container 
 Example:
 
 ```yaml
-ibm-application-gateway.security.ibm.com/deployment.image: icr.io/ibmappgateway/ibm-application-gateway:26.03
+ibm-application-gateway.security.ibm.com/deployment.image: icr.io/ibmappgateway/ibm-application-gateway:26.06
 ibm-application-gateway.security.ibm.com/deployment.imagePullPolicy: IfNotPresent
 ```
 
@@ -1201,7 +1238,7 @@ metadata:
     ibm-application-gateway.security.ibm.com/configuration.sample.header.authz.name: Authorization
     ibm-application-gateway.security.ibm.com/configuration.sample.header.authz.value: githubsecret
     ibm-application-gateway.security.ibm.com/configuration.sample.header.authz.secretKey: value
-    ibm-application-gateway.security.ibm.com/deployment.image: icr.io/ibmappgateway/ibm-application-gateway:26.03
+    ibm-application-gateway.security.ibm.com/deployment.image: icr.io/ibmappgateway/ibm-application-gateway:26.06
     ibm-application-gateway.security.ibm.com/deployment.imagePullPolicy: IfNotPresent
     ibm-application-gateway.security.ibm.com/service.port: "30441"
 spec:

--- a/api/v1/ibmapplicationgateway_types.go
+++ b/api/v1/ibmapplicationgateway_types.go
@@ -156,7 +156,7 @@ type IBMApplicationGatewayConfiguration struct {
 	// type is web.
 	// +optional
 	// +kubebuilder:validation:Pattern=`^https://`
-	Url string `json:"url"`
+	Url string `json:"url,omitempty"`
 
 	// Any headers which are associated with the request which is sent to
 	// retrieve configuration data.  Used when type is web.
@@ -170,7 +170,7 @@ type IBMApplicationGatewayConfiguration struct {
 	// The OIDC discovery endpoint.  Used when type is oidc_registration.
 	// +optional
 	// +kubebuilder:validation:Pattern=`^https://`
-	DiscoveryEndpoint string `json:"discoveryEndpoint"`
+	DiscoveryEndpoint string `json:"discoveryEndpoint,omitempty"`
 
 	// The name of the secret which contains the credential information.  Used
 	// when type is oidc_registration.

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=ibm-application-gateway-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=stable
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.37.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.42.3
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 

--- a/config/network-policy/operator-egress.yaml
+++ b/config/network-policy/operator-egress.yaml
@@ -15,12 +15,18 @@
 # kube-system, where the API server endpoint lives in most managed Kubernetes
 # distributions (IKS, OCP, EKS, GKE).  On bare-metal clusters where the
 # apiserver is not a pod, add an ipBlock entry with your control-plane CIDR.
+#
+# NOTE: This manifest is applied by kustomize/kubectl only.  OLM does not
+# support NetworkPolicy objects in bundle manifests (unsupported media type);
+# OLM users should apply this file manually after installation:
+#
+#   kubectl apply -f config/network-policy/operator-egress.yaml -n <operator-namespace>
+#
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: controller-manager-egress
-  namespace: system
 spec:
   podSelector:
     matchLabels:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,6 +9,7 @@ rules:
   resources:
   - configmaps
   - secrets
+  - services
   verbs:
   - create
   - delete

--- a/config/samples/ibm_v1_ibmapplicationgateway.yaml
+++ b/config/samples/ibm_v1_ibmapplicationgateway.yaml
@@ -9,7 +9,7 @@ spec:
   deployment:
     serviceAccountName: iag
     lang: C
-    image: icr.io/ibmappgateway/ibm-application-gateway:26.03
+    image: icr.io/ibmappgateway/ibm-application-gateway:26.06
     imagePullPolicy: Always
     imagePullSecrets: 
       - name: regcred

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
+	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.31.0
 	k8s.io/apimachinery v0.31.0
@@ -55,6 +56,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect

--- a/internal/controller/ibmapplicationgateway_controller.go
+++ b/internal/controller/ibmapplicationgateway_controller.go
@@ -97,6 +97,7 @@ type IBMApplicationGatewayReconciler struct {
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=ibm.com,resources=ibmapplicationgateways,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=ibm.com,resources=ibmapplicationgateways/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=ibm.com,resources=ibmapplicationgateways/finalizers,verbs=update

--- a/test/e2e/annotations_test.go
+++ b/test/e2e/annotations_test.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright contributors to the IBM Application Gateway Operator project
+ */
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ibmv1 "github.com/ibm-security/ibm-application-gateway-operator/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestILMTAnnotationsPresent asserts that the operator always stamps the IBM
+// License Metric Tool (ILMT) annotations onto the managed pod template.
+// These are required for IBM product compliance and are always applied by
+// newDeploymentForCR regardless of the licenseAnnotation field value.
+func TestILMTAnnotationsPresent(t *testing.T) {
+	ensureNamespace(t)
+	ensureServiceAccount(t)
+
+	crName := "iag-ilmt-test"
+	cr := buildIAGCR(crName, testNamespace, iagImage,
+		"version: \"26.7\"\n")
+	require.NoError(t, c.Create(context.Background(), cr))
+	t.Cleanup(func() { _ = c.Delete(context.Background(), cr) })
+
+	waitForDeployment(t, crName, shortTimeout)
+
+	d := getDeployment(t, crName)
+	podAnnotations := d.Spec.Template.Annotations
+
+	assert.Equal(t, "IBM Application Gateway", podAnnotations["productName"],
+		"ILMT productName must be set on pod template")
+	assert.Equal(t, "7c3292bae26f4f699486bc4b8d05166c", podAnnotations["productId"],
+		"ILMT productId must be set on pod template")
+	assert.Equal(t, "PROCESSOR_VALUE_UNIT", podAnnotations["productMetric"],
+		"ILMT productMetric must be set on pod template")
+	assert.Equal(t, "All", podAnnotations["productChargedContainers"],
+		"ILMT productChargedContainers must be set on pod template")
+}
+
+// TestCustomAnnotationsForwarded asserts that custom annotations defined in
+// spec.deployment.customAnnotations are added to the pod template by the operator.
+func TestCustomAnnotationsForwarded(t *testing.T) {
+	ensureNamespace(t)
+	ensureServiceAccount(t)
+
+	crName := "iag-custom-annot-test"
+	cr := &ibmv1.IBMApplicationGateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      crName,
+			Namespace: testNamespace,
+		},
+		Spec: ibmv1.IBMApplicationGatewaySpec{
+			Replicas: 1,
+			Deployment: ibmv1.IBMApplicationGatewayDeployment{
+				ImageLocation:   iagImage,
+				ImagePullPolicy: "IfNotPresent",
+				Lang:            "C",
+				CustomAnnotations: []ibmv1.CustomAnnotation{
+					{Key: "my-org/owner", Value: "team-alpha"},
+					{Key: "my-org/env", Value: "e2e-test"},
+				},
+			},
+			Configuration: []ibmv1.IBMApplicationGatewayConfiguration{
+				{Type: "literal", Value: "version: \"26.7\"\n"},
+			},
+		},
+	}
+	require.NoError(t, c.Create(context.Background(), cr))
+	t.Cleanup(func() { _ = c.Delete(context.Background(), cr) })
+
+	waitForDeployment(t, crName, shortTimeout)
+
+	d := getDeployment(t, crName)
+	podAnnotations := d.Spec.Template.Annotations
+
+	assert.Equal(t, "team-alpha", podAnnotations["my-org/owner"],
+		"custom annotation my-org/owner must be present on pod template")
+	assert.Equal(t, "e2e-test", podAnnotations["my-org/env"],
+		"custom annotation my-org/env must be present on pod template")
+}

--- a/test/e2e/configmap_suffix_test.go
+++ b/test/e2e/configmap_suffix_test.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright contributors to the IBM Application Gateway Operator project
+ */
+
+package e2e
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ibmv1 "github.com/ibm-security/ibm-application-gateway-operator/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestCustomConfigMapSuffix verifies that setting spec.deployment.generatedConfigmapSuffix
+// causes the operator to use the custom suffix when naming the master ConfigMap.
+// The controller builds the GenerateName as: <crName><suffix> (via getConfigMapName).
+// Default suffix is "-config-iag-internal-generated"; this test overrides it.
+func TestCustomConfigMapSuffix(t *testing.T) {
+	ensureNamespace(t)
+	ensureServiceAccount(t)
+
+	crName := "iag-suffix-test"
+	customSuffix := "-my-custom-suffix"
+
+	cr := &ibmv1.IBMApplicationGateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      crName,
+			Namespace: testNamespace,
+		},
+		Spec: ibmv1.IBMApplicationGatewaySpec{
+			Replicas: 1,
+			Deployment: ibmv1.IBMApplicationGatewayDeployment{
+				ImageLocation:   iagImage,
+				ImagePullPolicy: "IfNotPresent",
+				Lang:            "C",
+				ConfigMapSuffix: customSuffix,
+			},
+			Configuration: []ibmv1.IBMApplicationGatewayConfiguration{
+				{Type: "literal", Value: "version: \"26.7\"\n"},
+			},
+		},
+	}
+	require.NoError(t, c.Create(context.Background(), cr))
+	t.Cleanup(func() { _ = c.Delete(context.Background(), cr) })
+
+	waitForDeployment(t, crName, shortTimeout)
+
+	// Fetch the master ConfigMap by label.
+	var cmList corev1.ConfigMapList
+	require.NoError(t, c.List(context.Background(), &cmList,
+		client.InNamespace(testNamespace),
+		client.MatchingLabels{"app": crName},
+	))
+	require.NotEmpty(t, cmList.Items,
+		"master ConfigMap with label app=%q should exist", crName)
+
+	cm := cmList.Items[0]
+
+	// The controller sets GenerateName = crName + suffix.
+	// The actual Name will be that prefix with a random suffix appended by k8s.
+	// We assert the Name starts with the expected prefix.
+	expectedPrefix := crName + customSuffix
+	assert.True(t,
+		strings.HasPrefix(cm.Name, expectedPrefix),
+		"ConfigMap name %q should start with %q", cm.Name, expectedPrefix)
+}

--- a/test/e2e/configmap_test.go
+++ b/test/e2e/configmap_test.go
@@ -1,0 +1,170 @@
+/*
+ * Copyright contributors to the IBM Application Gateway Operator project
+ */
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	ibmv1 "github.com/ibm-security/ibm-application-gateway-operator/api/v1"
+)
+
+const configMapTestCRName = "iag-configmap-test"
+
+// TestConfigMapSourceCreatesDeployment creates an IBMApplicationGateway CR that
+// references a ConfigMap as its configuration source and asserts that the
+// operator creates a Deployment and master ConfigMap containing the expected data.
+func TestConfigMapSourceCreatesDeployment(t *testing.T) {
+	ensureNamespace(t)
+	ensureServiceAccount(t)
+
+	// Source ConfigMap that the CR will reference.
+	sourceData := `
+version: "26.7"
+server:
+  local_applications:
+    cred_viewer:
+      path_segment: "creds"
+      enable_html: true
+`
+	sourceCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "iag-source-cm",
+			Namespace: testNamespace,
+		},
+		Data: map[string]string{
+			"config.yaml": sourceData,
+		},
+	}
+	require.NoError(t, c.Create(context.Background(), sourceCM))
+	t.Cleanup(func() { _ = c.Delete(context.Background(), sourceCM) })
+
+	// CR referencing the ConfigMap.
+	cr := &ibmv1.IBMApplicationGateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapTestCRName,
+			Namespace: testNamespace,
+		},
+		Spec: ibmv1.IBMApplicationGatewaySpec{
+			Replicas: 1,
+			Deployment: ibmv1.IBMApplicationGatewayDeployment{
+				ImageLocation:   iagImage,
+				ImagePullPolicy: "IfNotPresent",
+				Lang:            "C",
+			},
+			Configuration: []ibmv1.IBMApplicationGatewayConfiguration{
+				{
+					Type:    "configmap",
+					Name:    "iag-source-cm",
+					DataKey: "config.yaml",
+				},
+			},
+		},
+	}
+	require.NoError(t, c.Create(context.Background(), cr))
+	t.Cleanup(func() { _ = c.Delete(context.Background(), cr) })
+
+	waitForDeployment(t, configMapTestCRName, shortTimeout)
+
+	// The master ConfigMap must contain the content from the source ConfigMap.
+	waitForMasterConfigMapContent(t, configMapTestCRName, "cred_viewer", shortTimeout)
+}
+
+// TestConfigMapUpdateTriggersReconcile updates the source ConfigMap and asserts
+// that the master ConfigMap is updated to reflect the new content.
+func TestConfigMapUpdateTriggersReconcile(t *testing.T) {
+	ensureNamespace(t)
+	ensureServiceAccount(t)
+
+	// Source ConfigMap v1.
+	sourceData := `
+version: "26.7"
+server:
+  local_applications:
+    cred_viewer:
+      path_segment: "creds-v1"
+      enable_html: true
+`
+	sourceCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "iag-update-source-cm",
+			Namespace: testNamespace,
+		},
+		Data: map[string]string{
+			"config.yaml": sourceData,
+		},
+	}
+	require.NoError(t, c.Create(context.Background(), sourceCM))
+	t.Cleanup(func() { _ = c.Delete(context.Background(), sourceCM) })
+
+	crName := "iag-update-cm-test"
+	cr := &ibmv1.IBMApplicationGateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      crName,
+			Namespace: testNamespace,
+		},
+		Spec: ibmv1.IBMApplicationGatewaySpec{
+			Replicas: 1,
+			Deployment: ibmv1.IBMApplicationGatewayDeployment{
+				ImageLocation:   iagImage,
+				ImagePullPolicy: "IfNotPresent",
+				Lang:            "C",
+			},
+			Configuration: []ibmv1.IBMApplicationGatewayConfiguration{
+				{
+					Type:    "configmap",
+					Name:    "iag-update-source-cm",
+					DataKey: "config.yaml",
+				},
+			},
+		},
+	}
+	require.NoError(t, c.Create(context.Background(), cr))
+	t.Cleanup(func() { _ = c.Delete(context.Background(), cr) })
+
+	// Wait for initial reconcile.
+	waitForDeployment(t, crName, shortTimeout)
+	waitForMasterConfigMapContent(t, crName, "creds-v1", shortTimeout)
+
+	// Record the current master ConfigMap ResourceVersion so we can detect the update.
+	initial := masterConfigMap(t, crName)
+	initialRV := initial.ResourceVersion
+
+	// Patch the source ConfigMap to use a new path_segment.
+	updatedData := `
+version: "26.7"
+server:
+  local_applications:
+    cred_viewer:
+      path_segment: "creds-v2"
+      enable_html: true
+`
+	patch := sourceCM.DeepCopy()
+	patch.Data["config.yaml"] = updatedData
+	require.NoError(t, c.Update(context.Background(), patch))
+
+	// Wait for the master ConfigMap to be updated (ResourceVersion must change).
+	require.Eventually(t, func() bool {
+		var cmList corev1.ConfigMapList
+		if err := c.List(context.Background(), &cmList,
+			client.InNamespace(testNamespace),
+			client.MatchingLabels{"app": crName},
+		); err != nil || len(cmList.Items) == 0 {
+			return false
+		}
+		return cmList.Items[0].ResourceVersion != initialRV
+	}, shortTimeout, pollInterval,
+		"master ConfigMap for %q was not updated after source ConfigMap change", crName)
+
+	// Assert new content is present.
+	assert.True(t, contains(masterConfigMap(t, crName).Data["config.yaml"], "creds-v2"),
+		"master ConfigMap should contain updated path_segment creds-v2")
+}

--- a/test/e2e/deletion_test.go
+++ b/test/e2e/deletion_test.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright contributors to the IBM Application Gateway Operator project
+ */
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestCRDeletionCleansUpOwnedResources creates a fresh CR, waits for its
+// Deployment and master ConfigMap to appear, deletes the CR, then asserts that
+// both the Deployment and ConfigMap are garbage-collected.
+func TestCRDeletionCleansUpOwnedResources(t *testing.T) {
+	ensureNamespace(t)
+	ensureServiceAccount(t)
+
+	crName := "iag-delete-test"
+	cr := buildIAGCR(crName, testNamespace, iagImage,
+		"version: \"26.7\"\n")
+	require.NoError(t, c.Create(context.Background(), cr))
+
+	// Wait for the Deployment and master ConfigMap to exist before deleting.
+	waitForDeployment(t, crName, shortTimeout)
+	waitForMasterConfigMapContent(t, crName, "version", shortTimeout)
+
+	// Delete the CR; owned resources should be garbage-collected.
+	require.NoError(t, c.Delete(context.Background(), cr))
+
+	// Deployment should disappear.
+	waitForDeploymentGone(t, crName, shortTimeout)
+
+	// Master ConfigMap (label app=<crName>) should also be gone.
+	require.Eventually(t, func() bool {
+		var cmList corev1.ConfigMapList
+		if err := c.List(context.Background(), &cmList,
+			client.InNamespace(testNamespace),
+			client.MatchingLabels{"app": crName},
+		); err != nil {
+			return false
+		}
+		return len(cmList.Items) == 0
+	}, shortTimeout, pollInterval,
+		"master ConfigMap for %q was not garbage-collected after CR deletion", crName)
+
+	// No ReplicaSets labelled app=<crName> should remain.
+	require.Eventually(t, func() bool {
+		var rsList appsv1.ReplicaSetList
+		if err := c.List(context.Background(), &rsList,
+			client.InNamespace(testNamespace),
+			client.MatchingLabels{"app": crName},
+		); err != nil {
+			return false
+		}
+		return len(rsList.Items) == 0
+	}, shortTimeout, pollInterval,
+		"ReplicaSets for %q were not cleaned up after CR deletion", crName)
+
+	assert.True(t, true, "all owned resources were cleaned up")
+}

--- a/test/e2e/deploy_cr_test.go
+++ b/test/e2e/deploy_cr_test.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright contributors to the IBM Application Gateway Operator project
+ */
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeploymentCreated verifies that creating an IBMApplicationGateway CR
+// causes the controller to create a Deployment and a master ConfigMap.
+func TestDeploymentCreated(t *testing.T) {
+	ensureNamespace(t)
+	ensureServiceAccount(t)
+
+	crName := "iag-deploy-test"
+	literalConfig := `
+version: "26.7"
+server:
+  local_applications:
+    cred_viewer:
+      path_segment: "creds"
+      enable_html: true
+`
+	cr := buildIAGCR(crName, testNamespace, iagImage, literalConfig)
+	require.NoError(t, c.Create(context.Background(), cr))
+	t.Cleanup(func() {
+		_ = c.Delete(context.Background(), cr)
+	})
+
+	// Wait for the Deployment to be created.
+	waitForDeployment(t, crName, shortTimeout)
+
+	// Assert the Deployment has the expected replica count.
+	d := getDeployment(t, crName)
+	require.NotNil(t, d.Spec.Replicas, "Deployment.Spec.Replicas should not be nil")
+	assert.Equal(t, int32(1), *d.Spec.Replicas, "expected 1 replica")
+
+	// Assert the master ConfigMap was created and contains the config.
+	cm := masterConfigMap(t, crName)
+	assert.True(t, len(cm.Data["config.yaml"]) > 0, "master ConfigMap config.yaml should not be empty")
+
+	// ConfigMap is owned by the CR so it will be GC'd; delete here to speed up
+	// namespace cleanup.
+	_ = c.Delete(context.Background(), cm)
+}
+
+// TestDeploymentLabels verifies that the created Deployment carries the
+// app=<crName> selector label that the operator always sets.
+func TestDeploymentLabels(t *testing.T) {
+	ensureNamespace(t)
+	ensureServiceAccount(t)
+
+	crName := "iag-labels-test"
+	cr := buildIAGCR(crName, testNamespace, iagImage,
+		"version: \"26.7\"\n")
+	require.NoError(t, c.Create(context.Background(), cr))
+	t.Cleanup(func() {
+		_ = c.Delete(context.Background(), cr)
+	})
+
+	waitForDeployment(t, crName, shortTimeout)
+
+	d := getDeployment(t, crName)
+	assert.Equal(t, crName, d.Labels["app"],
+		"Deployment should carry label app=<crName>")
+	assert.Equal(t, crName, d.Spec.Selector.MatchLabels["app"],
+		"Deployment selector should match app=<crName>")
+}

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -1,0 +1,153 @@
+/*
+ * Copyright contributors to the IBM Application Gateway Operator project
+ */
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	ibmv1 "github.com/ibm-security/ibm-application-gateway-operator/api/v1"
+)
+
+const (
+	pollInterval = 3 * time.Second
+	shortTimeout = 2 * time.Minute
+	longTimeout  = 5 * time.Minute
+)
+
+// ensureNamespace creates the test namespace if it does not already exist.
+// The namespace is intentionally not deleted in Cleanup — tests share it for
+// the lifetime of the suite run, and deleting it mid-run causes "namespace
+// being terminated" failures in concurrently executing tests.
+func ensureNamespace(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}}
+	_ = c.Create(ctx, ns) // ignore AlreadyExists
+}
+
+// ensureServiceAccount creates the "iag" ServiceAccount used by test CRs.
+// Errors are intentionally ignored — the SA may already exist.
+func ensureServiceAccount(t *testing.T) {
+	t.Helper()
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "iag", Namespace: testNamespace},
+	}
+	_ = c.Create(context.Background(), sa)
+}
+
+// waitForDeployment polls until the named Deployment exists in testNamespace.
+func waitForDeployment(t *testing.T, name string, timeout time.Duration) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		var d appsv1.Deployment
+		return c.Get(context.Background(),
+			client.ObjectKey{Name: name, Namespace: testNamespace}, &d) == nil
+	}, timeout, pollInterval, "deployment %q was not created within %s", name, timeout)
+}
+
+// waitForDeploymentGone polls until the named Deployment is absent from testNamespace.
+func waitForDeploymentGone(t *testing.T, name string, timeout time.Duration) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		var d appsv1.Deployment
+		err := c.Get(context.Background(),
+			client.ObjectKey{Name: name, Namespace: testNamespace}, &d)
+		return errors.IsNotFound(err)
+	}, timeout, pollInterval, "deployment %q was not deleted within %s", name, timeout)
+}
+
+// masterConfigMap returns the operator-generated merged ConfigMap for a CR.
+// It is found by the label app=<crName>, which the controller always sets via
+// getNewConfigMap in ibmapplicationgateway_controller.go.
+func masterConfigMap(t *testing.T, crName string) *corev1.ConfigMap {
+	t.Helper()
+	var cmList corev1.ConfigMapList
+	require.NoError(t, c.List(context.Background(), &cmList,
+		client.InNamespace(testNamespace),
+		client.MatchingLabels{"app": crName},
+	))
+	require.NotEmpty(t, cmList.Items, "no master ConfigMap found for CR %q", crName)
+	return &cmList.Items[0]
+}
+
+// waitForMasterConfigMapContent polls until the master ConfigMap for crName
+// contains the given substring in its config.yaml data key.
+func waitForMasterConfigMapContent(t *testing.T, crName, substring string, timeout time.Duration) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		var cmList corev1.ConfigMapList
+		if err := c.List(context.Background(), &cmList,
+			client.InNamespace(testNamespace),
+			client.MatchingLabels{"app": crName},
+		); err != nil {
+			return false
+		}
+		if len(cmList.Items) == 0 {
+			return false
+		}
+		data := cmList.Items[0].Data["config.yaml"]
+		return len(data) > 0 && contains(data, substring)
+	}, timeout, pollInterval,
+		"master ConfigMap for %q did not contain %q within %s", crName, substring, timeout)
+}
+
+// getDeployment returns the named Deployment from testNamespace, failing the
+// test if the Deployment cannot be retrieved.
+func getDeployment(t *testing.T, name string) appsv1.Deployment {
+	t.Helper()
+	var d appsv1.Deployment
+	require.NoError(t, c.Get(context.Background(),
+		client.ObjectKey{Name: name, Namespace: testNamespace}, &d),
+		"failed to get Deployment %q", name)
+	return d
+}
+
+// buildIAGCR constructs a minimal IBMApplicationGateway CR with a single
+// literal configuration entry. It does NOT create it in the cluster.
+func buildIAGCR(name, namespace, image, literalConfig string) *ibmv1.IBMApplicationGateway {
+	replicas := int32(1)
+	return &ibmv1.IBMApplicationGateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: ibmv1.IBMApplicationGatewaySpec{
+			Replicas: replicas,
+			Deployment: ibmv1.IBMApplicationGatewayDeployment{
+				ImageLocation:   image,
+				ImagePullPolicy: "IfNotPresent",
+				Lang:            "C",
+			},
+			Configuration: []ibmv1.IBMApplicationGatewayConfiguration{
+				{
+					Type:  "literal",
+					Value: literalConfig,
+				},
+			},
+		},
+	}
+}
+
+// contains is a simple helper that avoids importing strings in every test file.
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
+		func() bool {
+			for i := 0; i <= len(s)-len(sub); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+			return false
+		}())
+}

--- a/test/e2e/image_test.go
+++ b/test/e2e/image_test.go
@@ -1,0 +1,81 @@
+/*
+ * Copyright contributors to the IBM Application Gateway Operator project
+ */
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestImageChangeRollingUpdate patches the CR's image and asserts that the
+// Deployment template container image is updated and the change-cause annotation
+// is set on the Deployment.
+func TestImageChangeRollingUpdate(t *testing.T) {
+	ensureNamespace(t)
+	ensureServiceAccount(t)
+
+	crName := "iag-image-test"
+	cr := buildIAGCR(crName, testNamespace, iagImage, "version: \"26.7\"\n")
+	require.NoError(t, c.Create(context.Background(), cr))
+	t.Cleanup(func() { _ = c.Delete(context.Background(), cr) })
+
+	waitForDeployment(t, crName, shortTimeout)
+
+	// Verify the initial image is set correctly.
+	d := getDeployment(t, crName)
+	require.Equal(t, iagImage, d.Spec.Template.Spec.Containers[0].Image,
+		"initial container image should match CR spec")
+
+	// Re-fetch CR to get current ResourceVersion before patching.
+	require.NoError(t, c.Get(context.Background(),
+		client.ObjectKey{Name: crName, Namespace: testNamespace}, cr))
+	cr.Spec.Deployment.ImageLocation = iagAltImage
+	require.NoError(t, c.Update(context.Background(), cr))
+
+	// Wait for the Deployment container image to be updated, and capture the
+	// Deployment once the image matches so we can assert the annotation in the
+	// same object version (avoids a race between a second Get and a controller
+	// update that clears the annotation).
+	var updatedDep appsv1.Deployment
+	require.Eventually(t, func() bool {
+		var dep appsv1.Deployment
+		if err := c.Get(context.Background(),
+			client.ObjectKey{Name: crName, Namespace: testNamespace}, &dep); err != nil {
+			return false
+		}
+		if len(dep.Spec.Template.Spec.Containers) == 0 {
+			return false
+		}
+		if dep.Spec.Template.Spec.Containers[0].Image != iagAltImage {
+			return false
+		}
+		updatedDep = dep
+		return true
+	}, longTimeout, pollInterval,
+		"Deployment container image was not updated to %q", iagAltImage)
+
+	// Assert the Deployment annotation records the reason for the rollout.
+	assert.True(t,
+		contains(updatedDep.Annotations["kubernetes.io/change-cause"], "Image changed"),
+		"Deployment annotation kubernetes.io/change-cause should contain 'Image changed', got %q",
+		updatedDep.Annotations["kubernetes.io/change-cause"],
+	)
+
+	// Restore the original image in Cleanup so other tests are not affected.
+	t.Cleanup(func() {
+		var crLatest = cr.DeepCopy()
+		if err := c.Get(context.Background(),
+			client.ObjectKey{Name: crName, Namespace: testNamespace}, crLatest); err != nil {
+			return
+		}
+		crLatest.Spec.Deployment.ImageLocation = iagImage
+		_ = c.Update(context.Background(), crLatest)
+	})
+}

--- a/test/e2e/lang_test.go
+++ b/test/e2e/lang_test.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright contributors to the IBM Application Gateway Operator project
+ */
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// langLabelKeyE2E mirrors the controller constant so tests do not import internal packages.
+const langLabelKeyE2E = "ibm-application-gateway.operator.security.ibm.com/lang"
+
+// TestLanguageChangeAnnotatesRollout patches spec.deployment.lang and asserts that
+// the controller updates:
+//   - the pod template LANG env var
+//   - the pod template label ibm-application-gateway.operator.security.ibm.com/lang
+//   - Deployment.Annotations["kubernetes.io/change-cause"] (contains "Language changed")
+func TestLanguageChangeAnnotatesRollout(t *testing.T) {
+	ensureNamespace(t)
+	ensureServiceAccount(t)
+
+	crName := "iag-lang-test"
+	cr := buildIAGCR(crName, testNamespace, iagImage,
+		"version: \"26.7\"\n")
+	// Start with the default language (C / English).
+	cr.Spec.Deployment.Lang = "C"
+	require.NoError(t, c.Create(context.Background(), cr))
+	t.Cleanup(func() { _ = c.Delete(context.Background(), cr) })
+
+	waitForDeployment(t, crName, shortTimeout)
+
+	// Confirm the initial language label on the pod template.
+	d := getDeployment(t, crName)
+	assert.Equal(t, "C", d.Spec.Template.Labels[langLabelKeyE2E],
+		"initial pod template label should be lang=C")
+
+	// Patch the CR to use French.
+	require.NoError(t, c.Get(context.Background(),
+		client.ObjectKey{Name: crName, Namespace: testNamespace}, cr))
+	cr.Spec.Deployment.Lang = "fr"
+	require.NoError(t, c.Update(context.Background(), cr))
+
+	// Wait for the Deployment template label to reflect the new language.
+	require.Eventually(t, func() bool {
+		var dep appsv1.Deployment
+		if err := c.Get(context.Background(),
+			client.ObjectKey{Name: crName, Namespace: testNamespace}, &dep); err != nil {
+			return false
+		}
+		return dep.Spec.Template.Labels[langLabelKeyE2E] == "fr"
+	}, shortTimeout, pollInterval,
+		"pod template label %s was not updated to 'fr'", langLabelKeyE2E)
+
+	d = getDeployment(t, crName)
+
+	// LANG env var must be set to "fr" in the container spec.
+	var foundLang string
+	for _, env := range d.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == "LANG" {
+			foundLang = env.Value
+		}
+	}
+	assert.Equal(t, "fr", foundLang,
+		"container LANG env var should be updated to fr")
+
+	// change-cause must contain "Language changed".
+	assert.True(t,
+		contains(d.Annotations["kubernetes.io/change-cause"], "Language changed"),
+		"change-cause annotation should contain 'Language changed', got: %q",
+		d.Annotations["kubernetes.io/change-cause"])
+}

--- a/test/e2e/literal_test.go
+++ b/test/e2e/literal_test.go
@@ -1,0 +1,117 @@
+/*
+ * Copyright contributors to the IBM Application Gateway Operator project
+ */
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestLiteralConfigChangeRegeneratesConfigMap patches the CR's literal config and
+// asserts that the master ConfigMap is updated (ResourceVersion changes).
+func TestLiteralConfigChangeRegeneratesConfigMap(t *testing.T) {
+	ensureNamespace(t)
+	ensureServiceAccount(t)
+
+	crName := "iag-literal-test"
+	initialConfig := `
+version: "26.7"
+server:
+  local_applications:
+    cred_viewer:
+      path_segment: "creds-initial"
+      enable_html: true
+`
+	cr := buildIAGCR(crName, testNamespace, iagImage,
+		initialConfig)
+	require.NoError(t, c.Create(context.Background(), cr))
+	t.Cleanup(func() { _ = c.Delete(context.Background(), cr) })
+
+	waitForDeployment(t, crName, shortTimeout)
+	waitForMasterConfigMapContent(t, crName, "creds-initial", shortTimeout)
+
+	// Record the initial ConfigMap ResourceVersion.
+	initialCM := masterConfigMap(t, crName)
+	initialRV := initialCM.ResourceVersion
+
+	// Patch the CR literal config to use a new path_segment.
+	updatedConfig := `
+version: "26.7"
+server:
+  local_applications:
+    cred_viewer:
+      path_segment: "creds-updated"
+      enable_html: true
+`
+	require.NoError(t, c.Get(context.Background(),
+		client.ObjectKey{Name: crName, Namespace: testNamespace}, cr))
+	cr.Spec.Configuration[0].Value = updatedConfig
+	require.NoError(t, c.Update(context.Background(), cr))
+
+	// Wait for the master ConfigMap to change.
+	require.Eventually(t, func() bool {
+		var cmList corev1.ConfigMapList
+		if err := c.List(context.Background(), &cmList,
+			client.InNamespace(testNamespace),
+			client.MatchingLabels{"app": crName},
+		); err != nil || len(cmList.Items) == 0 {
+			return false
+		}
+		return cmList.Items[0].ResourceVersion != initialRV
+	}, shortTimeout, pollInterval,
+		"master ConfigMap for %q was not updated after literal config change", crName)
+
+	// Assert the new content is present.
+	cm := masterConfigMap(t, crName)
+	assert.True(t, contains(cm.Data["config.yaml"], "creds-updated"),
+		"master ConfigMap should contain the updated path_segment creds-updated")
+}
+
+// TestLiteralConfigChangeAnnotatesRollout asserts that a literal config change
+// sets kubernetes.io/change-cause = "Configuration change" on the Deployment.
+func TestLiteralConfigChangeAnnotatesRollout(t *testing.T) {
+	ensureNamespace(t)
+	ensureServiceAccount(t)
+
+	crName := "iag-annot-test"
+	initialConfig := "version: \"26.7\"\n"
+	cr := buildIAGCR(crName, testNamespace, iagImage,
+		initialConfig)
+	require.NoError(t, c.Create(context.Background(), cr))
+	t.Cleanup(func() { _ = c.Delete(context.Background(), cr) })
+
+	waitForDeployment(t, crName, shortTimeout)
+
+	// Apply a new literal config.
+	updatedConfig := `
+version: "26.7"
+server:
+  local_applications:
+    cred_viewer:
+      path_segment: "creds-annot"
+      enable_html: true
+`
+	require.NoError(t, c.Get(context.Background(),
+		client.ObjectKey{Name: crName, Namespace: testNamespace}, cr))
+	cr.Spec.Configuration[0].Value = updatedConfig
+	require.NoError(t, c.Update(context.Background(), cr))
+
+	// Wait for the Deployment to carry the expected change-cause annotation.
+	require.Eventually(t, func() bool {
+		var dep appsv1.Deployment
+		if err := c.Get(context.Background(),
+			client.ObjectKey{Name: crName, Namespace: testNamespace}, &dep); err != nil {
+			return false
+		}
+		return dep.Annotations["kubernetes.io/change-cause"] == "Configuration change"
+	}, shortTimeout, pollInterval,
+		"Deployment %q did not get change-cause=Configuration change", crName)
+}

--- a/test/e2e/merge_test.go
+++ b/test/e2e/merge_test.go
@@ -1,0 +1,132 @@
+/*
+ * Copyright contributors to the IBM Application Gateway Operator project
+ */
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ibmv1 "github.com/ibm-security/ibm-application-gateway-operator/api/v1"
+)
+
+// TestSplitConfigMergedInOrder verifies the README's "Split Configuration Example"
+// scalar-overwrite rule: when two sources define the same key, the later source wins.
+//
+// CR has two literal sources:
+//   - source 1: version: "26.6"
+//   - source 2: version: "26.7"
+//
+// Expected merged output: version: "26.7"  (source 2 overwrites source 1)
+func TestSplitConfigMergedInOrder(t *testing.T) {
+	ensureNamespace(t)
+	ensureServiceAccount(t)
+
+	crName := "iag-merge-scalar-test"
+	cr := &ibmv1.IBMApplicationGateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      crName,
+			Namespace: testNamespace,
+		},
+		Spec: ibmv1.IBMApplicationGatewaySpec{
+			Replicas: 1,
+			Deployment: ibmv1.IBMApplicationGatewayDeployment{
+				ImageLocation:   iagImage,
+				ImagePullPolicy: "IfNotPresent",
+				Lang:            "C",
+			},
+			// Two literal sources with conflicting version keys.
+			// Controller merges in order; later entry overwrites earlier for scalars.
+			Configuration: []ibmv1.IBMApplicationGatewayConfiguration{
+				{
+					Type:  "literal",
+					Value: "version: \"26.6\"\n",
+				},
+				{
+					Type:  "literal",
+					Value: "version: \"26.7\"\n",
+				},
+			},
+		},
+	}
+	require.NoError(t, c.Create(context.Background(), cr))
+	t.Cleanup(func() { _ = c.Delete(context.Background(), cr) })
+
+	waitForDeployment(t, crName, shortTimeout)
+
+	// The master ConfigMap must contain the later value (26.7), not the earlier (26.6).
+	waitForMasterConfigMapContent(t, crName, "26.7", shortTimeout)
+	cm := masterConfigMap(t, crName)
+	assert.True(t, contains(cm.Data["config.yaml"], "26.7"),
+		"merged ConfigMap should contain version 26.7 (later source wins)")
+	assert.False(t, contains(cm.Data["config.yaml"], "26.6") &&
+		!contains(cm.Data["config.yaml"], "26.7"),
+		"merged ConfigMap must not contain only the earlier version 26.6")
+}
+
+// TestSplitConfigArraysConcatenated verifies the README's array-concatenation rule:
+// when two sources each define entries in the same array, the merged output contains
+// all entries from both sources.
+//
+// CR has two literal sources each defining one resource_server entry.
+// Expected: merged ConfigMap contains paths from BOTH sources.
+func TestSplitConfigArraysConcatenated(t *testing.T) {
+	ensureNamespace(t)
+	ensureServiceAccount(t)
+
+	crName := "iag-merge-array-test"
+	cr := &ibmv1.IBMApplicationGateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      crName,
+			Namespace: testNamespace,
+		},
+		Spec: ibmv1.IBMApplicationGatewaySpec{
+			Replicas: 1,
+			Deployment: ibmv1.IBMApplicationGatewayDeployment{
+				ImageLocation:   iagImage,
+				ImagePullPolicy: "IfNotPresent",
+				Lang:            "C",
+			},
+			Configuration: []ibmv1.IBMApplicationGatewayConfiguration{
+				{
+					Type: "literal",
+					Value: `version: "26.7"
+resource_servers:
+  - path: /app1
+    connection_type: tcp
+    servers:
+      - host: 10.0.0.1
+        port: 8080
+`,
+				},
+				{
+					Type: "literal",
+					Value: `resource_servers:
+  - path: /app2
+    connection_type: tcp
+    servers:
+      - host: 10.0.0.2
+        port: 8081
+`,
+				},
+			},
+		},
+	}
+	require.NoError(t, c.Create(context.Background(), cr))
+	t.Cleanup(func() { _ = c.Delete(context.Background(), cr) })
+
+	waitForDeployment(t, crName, shortTimeout)
+	waitForMasterConfigMapContent(t, crName, "resource_servers", shortTimeout)
+
+	// Both resource server paths must appear in the merged ConfigMap.
+	cm := masterConfigMap(t, crName)
+	assert.True(t, contains(cm.Data["config.yaml"], "/app1"),
+		"merged ConfigMap should contain /app1 from first source")
+	assert.True(t, contains(cm.Data["config.yaml"], "/app2"),
+		"merged ConfigMap should contain /app2 from second source")
+}

--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -1,0 +1,102 @@
+/*
+ * Copyright contributors to the IBM Application Gateway Operator project
+ */
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	networkingv1 "k8s.io/api/networking/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// operatorNetPolName is the kustomize-expanded name of the egress NetworkPolicy:
+// namePrefix (ibm-application-gateway-operator-) + name in manifest (controller-manager-egress).
+const operatorNetPolName = "ibm-application-gateway-operator-controller-manager-egress"
+
+// TestEgressNetworkPolicyExists verifies that the egress NetworkPolicy shipped
+// in config/network-policy/operator-egress.yaml has been applied to the
+// operator namespace.  The policy must:
+//   - exist in the operator namespace
+//   - select pods with label control-plane=controller-manager
+//   - restrict only Egress traffic
+//   - have exactly three egress rules:
+//     1. DNS: UDP+TCP port 53 (any destination)
+//     2. kube-system HTTPS: TCP 443 to kube-system namespace
+//     3. External HTTPS: TCP 443 to 0.0.0.0/0 except 169.254.0.0/16
+func TestEgressNetworkPolicyExists(t *testing.T) {
+	var np networkingv1.NetworkPolicy
+	require.NoError(t,
+		c.Get(context.Background(),
+			client.ObjectKey{Name: operatorNetPolName, Namespace: operatorNS}, &np),
+		"NetworkPolicy %q must exist in namespace %q", operatorNetPolName, operatorNS)
+
+	// Must be Egress-only.
+	require.Len(t, np.Spec.PolicyTypes, 1,
+		"NetworkPolicy should have exactly one PolicyType")
+	assert.Equal(t, networkingv1.PolicyTypeEgress, np.Spec.PolicyTypes[0],
+		"PolicyType must be Egress")
+
+	// PodSelector must target the operator manager pods.
+	labels := np.Spec.PodSelector.MatchLabels
+	assert.Equal(t, "controller-manager", labels["control-plane"],
+		"PodSelector should match control-plane=controller-manager")
+
+	// Must have exactly 3 egress rules.
+	require.Len(t, np.Spec.Egress, 3,
+		"NetworkPolicy should have exactly 3 egress rules")
+
+	// --- Rule 0: DNS (UDP + TCP port 53) ---
+	dnsRule := np.Spec.Egress[0]
+	assert.Empty(t, dnsRule.To,
+		"DNS rule should have no destination (allow to any)")
+	require.Len(t, dnsRule.Ports, 2,
+		"DNS rule should have 2 port entries (UDP/53 and TCP/53)")
+
+	var hasDNSUDP, hasDNSTCP bool
+	for _, p := range dnsRule.Ports {
+		portNum := p.Port.IntValue()
+		if portNum == 53 {
+			switch *p.Protocol {
+			case "UDP":
+				hasDNSUDP = true
+			case "TCP":
+				hasDNSTCP = true
+			}
+		}
+	}
+	assert.True(t, hasDNSUDP, "DNS rule must allow UDP/53")
+	assert.True(t, hasDNSTCP, "DNS rule must allow TCP/53")
+
+	// --- Rule 1: kube-system HTTPS (TCP 443) ---
+	kubeRule := np.Spec.Egress[1]
+	require.Len(t, kubeRule.To, 1,
+		"kube-system rule should have exactly one To peer")
+	require.NotNil(t, kubeRule.To[0].NamespaceSelector,
+		"kube-system rule To peer must use a NamespaceSelector")
+	assert.Equal(t,
+		"kube-system",
+		kubeRule.To[0].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"],
+		"kube-system rule must target the kube-system namespace")
+	require.Len(t, kubeRule.Ports, 1)
+	assert.Equal(t, 443, kubeRule.Ports[0].Port.IntValue(),
+		"kube-system rule must allow port 443")
+
+	// --- Rule 2: External HTTPS with link-local exclusion ---
+	extRule := np.Spec.Egress[2]
+	require.Len(t, extRule.To, 1,
+		"external rule should have exactly one To peer")
+	require.NotNil(t, extRule.To[0].IPBlock,
+		"external rule To peer must use an IPBlock")
+	assert.Equal(t, "0.0.0.0/0", extRule.To[0].IPBlock.CIDR,
+		"external rule CIDR must be 0.0.0.0/0")
+	require.Contains(t, extRule.To[0].IPBlock.Except, "169.254.0.0/16",
+		"link-local 169.254.0.0/16 must be in the Except list")
+	require.Len(t, extRule.Ports, 1)
+	assert.Equal(t, 443, extRule.Ports[0].Port.IntValue(),
+		"external rule must allow port 443")
+}

--- a/test/e2e/replicas_test.go
+++ b/test/e2e/replicas_test.go
@@ -1,0 +1,91 @@
+/*
+ * Copyright contributors to the IBM Application Gateway Operator project
+ */
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// deploymentReplicas returns the replica count of the named Deployment, or -1
+// on any error (used inside require.Eventually callbacks).
+func deploymentReplicas(name string) int32 {
+	var d appsv1.Deployment
+	if err := c.Get(context.Background(),
+		client.ObjectKey{Name: name, Namespace: testNamespace}, &d); err != nil {
+		return -1
+	}
+	if d.Spec.Replicas == nil {
+		return -1
+	}
+	return *d.Spec.Replicas
+}
+
+// TestReplicaScaleUp creates an IAG CR with 1 replica, patches it to 3, and
+// asserts the Deployment reaches the new count.
+func TestReplicaScaleUp(t *testing.T) {
+	ensureNamespace(t)
+	ensureServiceAccount(t)
+
+	crName := "iag-scale-test"
+	cr := buildIAGCR(crName, testNamespace, iagImage,
+		"version: \"26.7\"\n")
+	require.NoError(t, c.Create(context.Background(), cr))
+	t.Cleanup(func() { _ = c.Delete(context.Background(), cr) })
+
+	waitForDeployment(t, crName, shortTimeout)
+
+	// Re-fetch to get current ResourceVersion before patching.
+	require.NoError(t, c.Get(context.Background(),
+		client.ObjectKey{Name: crName, Namespace: testNamespace}, cr))
+	cr.Spec.Replicas = 3
+	require.NoError(t, c.Update(context.Background(), cr))
+
+	require.Eventually(t, func() bool {
+		return deploymentReplicas(crName) == 3
+	}, shortTimeout, pollInterval, "Deployment %q did not scale up to 3 replicas", crName)
+
+	assert.Equal(t, int32(3), deploymentReplicas(crName))
+}
+
+// TestReplicaScaleDown creates a CR at 3 replicas, scales it to 1, and asserts
+// the Deployment is updated. Also verifies that kubernetes.io/change-cause is
+// NOT set for a replica-only change (per controller behaviour).
+func TestReplicaScaleDown(t *testing.T) {
+	ensureNamespace(t)
+	ensureServiceAccount(t)
+
+	crName := "iag-scaledown-test"
+	cr := buildIAGCR(crName, testNamespace, iagImage,
+		"version: \"26.7\"\n")
+	cr.Spec.Replicas = 3
+	require.NoError(t, c.Create(context.Background(), cr))
+	t.Cleanup(func() { _ = c.Delete(context.Background(), cr) })
+
+	waitForDeployment(t, crName, shortTimeout)
+	require.Eventually(t, func() bool {
+		return deploymentReplicas(crName) == 3
+	}, shortTimeout, pollInterval, "Deployment %q did not reach 3 replicas", crName)
+
+	// Re-fetch to get latest ResourceVersion before patching.
+	require.NoError(t, c.Get(context.Background(),
+		client.ObjectKey{Name: crName, Namespace: testNamespace}, cr))
+	cr.Spec.Replicas = 1
+	require.NoError(t, c.Update(context.Background(), cr))
+
+	require.Eventually(t, func() bool {
+		return deploymentReplicas(crName) == 1
+	}, shortTimeout, pollInterval, "Deployment %q did not scale down to 1 replica", crName)
+
+	// Replica-only changes must NOT set kubernetes.io/change-cause on the Deployment.
+	d := getDeployment(t, crName)
+	assert.Empty(t, d.Annotations["kubernetes.io/change-cause"],
+		"replica-only change must not set kubernetes.io/change-cause")
+}

--- a/test/e2e/serviceaccount_test.go
+++ b/test/e2e/serviceaccount_test.go
@@ -1,0 +1,72 @@
+/*
+ * Copyright contributors to the IBM Application Gateway Operator project
+ */
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestServiceAccountChangeAnnotatesRollout creates a CR with serviceAccountName="iag",
+// then patches it to a second SA and asserts that the Deployment template
+// ServiceAccountName is updated and change-cause records the reason.
+func TestServiceAccountChangeAnnotatesRollout(t *testing.T) {
+	ensureNamespace(t)
+	ensureServiceAccount(t) // creates "iag" SA
+
+	// Create a second service account for the patch target.
+	altSA := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "iag-alt", Namespace: testNamespace},
+	}
+	_ = c.Create(context.Background(), altSA) // ignore AlreadyExists
+	t.Cleanup(func() { _ = c.Delete(context.Background(), altSA) })
+
+	crName := "iag-sa-test"
+	cr := buildIAGCR(crName, testNamespace, iagImage,
+		"version: \"26.7\"\n")
+	cr.Spec.Deployment.ServiceAccountName = "iag"
+	require.NoError(t, c.Create(context.Background(), cr))
+	t.Cleanup(func() { _ = c.Delete(context.Background(), cr) })
+
+	waitForDeployment(t, crName, shortTimeout)
+
+	// Confirm initial service account.
+	d := getDeployment(t, crName)
+	assert.Equal(t, "iag", d.Spec.Template.Spec.ServiceAccountName,
+		"initial Deployment should use ServiceAccountName=iag")
+
+	// Patch CR to use the alternate SA.
+	require.NoError(t, c.Get(context.Background(),
+		client.ObjectKey{Name: crName, Namespace: testNamespace}, cr))
+	cr.Spec.Deployment.ServiceAccountName = "iag-alt"
+	require.NoError(t, c.Update(context.Background(), cr))
+
+	// Wait for the Deployment to reflect the new SA.
+	require.Eventually(t, func() bool {
+		var dep appsv1.Deployment
+		if err := c.Get(context.Background(),
+			client.ObjectKey{Name: crName, Namespace: testNamespace}, &dep); err != nil {
+			return false
+		}
+		return dep.Spec.Template.Spec.ServiceAccountName == "iag-alt"
+	}, shortTimeout, pollInterval,
+		"Deployment ServiceAccountName was not updated to 'iag-alt'")
+
+	d = getDeployment(t, crName)
+	assert.Equal(t, "iag-alt", d.Spec.Template.Spec.ServiceAccountName)
+
+	// change-cause must contain "Service account changed".
+	assert.True(t,
+		contains(d.Annotations["kubernetes.io/change-cause"], "Service account changed"),
+		"change-cause annotation should contain 'Service account changed', got: %q",
+		d.Annotations["kubernetes.io/change-cause"])
+}

--- a/test/e2e/sidecar_test.go
+++ b/test/e2e/sidecar_test.go
@@ -1,0 +1,245 @@
+/*
+ * Copyright contributors to the IBM Application Gateway Operator project
+ */
+
+package e2e
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// sidecarContainerNameFor returns the sidecar container name for a given
+// Deployment name, mirroring getAppName() in ibmapplicationgateway_webhook.go.
+func sidecarContainerNameFor(deploymentName string) string {
+	return strings.ToLower(deploymentName + "-ibm-application-gateway-sidecar-pod")
+}
+
+// newSidecarDeployment builds a Deployment object annotated for IAG sidecar
+// injection pointing at the named source ConfigMap on the given NodePort.
+func newSidecarDeployment(name, namespace, sourceCMName string, nodePort int) *appsv1.Deployment {
+	labels := map[string]string{"app": name}
+	replicas := int32(1)
+	annots := map[string]string{
+		"ibm-application-gateway.security.ibm.com/deployment.image":         iagImage,
+		"ibm-application-gateway.security.ibm.com/configuration.0.type":     "configmap",
+		"ibm-application-gateway.security.ibm.com/configuration.0.name":     sourceCMName,
+		"ibm-application-gateway.security.ibm.com/configuration.0.dataKey":  "config.yaml",
+		"ibm-application-gateway.security.ibm.com/configuration.0.order":    "1",
+	}
+	if nodePort > 0 {
+		annots["ibm-application-gateway.security.ibm.com/service.port"] = strconv.Itoa(nodePort)
+	}
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annots,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "busybox:latest"},
+					},
+				},
+			},
+		},
+	}
+}
+
+// waitForSidecarContainer polls until the named sidecar container appears in
+// the Deployment template.
+func waitForSidecarContainer(t *testing.T, deploymentName, containerName string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		var d appsv1.Deployment
+		if err := c.Get(context.Background(),
+			client.ObjectKey{Name: deploymentName, Namespace: testNamespace}, &d); err != nil {
+			return false
+		}
+		for _, ctr := range d.Spec.Template.Spec.Containers {
+			if ctr.Name == containerName {
+				return true
+			}
+		}
+		return false
+	}, shortTimeout, pollInterval,
+		"sidecar container %q was not injected into Deployment %q", containerName, deploymentName)
+}
+
+// cleanupSidecarResources deletes the sidecar ConfigMap and Service by label.
+// Called from t.Cleanup; errors are intentionally ignored.
+func cleanupSidecarResources(namespace, sidecarContainerName, deploymentName string) {
+	var cmList corev1.ConfigMapList
+	if err := c.List(context.Background(), &cmList,
+		client.InNamespace(namespace),
+		client.MatchingLabels{"app": sidecarContainerName},
+	); err == nil {
+		for i := range cmList.Items {
+			_ = c.Delete(context.Background(), &cmList.Items[i])
+		}
+	}
+	var svcList corev1.ServiceList
+	if err := c.List(context.Background(), &svcList,
+		client.InNamespace(namespace),
+		client.MatchingLabels{"app": deploymentName},
+	); err == nil {
+		for i := range svcList.Items {
+			_ = c.Delete(context.Background(), &svcList.Items[i])
+		}
+	}
+}
+
+// TestSidecarInjection deploys a plain Deployment carrying the IAG sidecar
+// annotations and asserts that the webhook:
+//   - injects the sidecar container named <deployment>-ibm-application-gateway-sidecar-pod
+//   - creates a ConfigMap with label app=<sidecarContainerName>
+//   - creates a NodePort Service with label app=<deploymentName> and nodePort 30443
+func TestSidecarInjection(t *testing.T) {
+	ensureNamespace(t)
+	ensureServiceAccount(t)
+
+	deploymentName := "iag-sidecar-test"
+	sidecarName := sidecarContainerNameFor(deploymentName)
+
+	sourceCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "iag-sidecar-source-cm", Namespace: testNamespace},
+		Data:       map[string]string{"config.yaml": "version: \"26.7\"\n"},
+	}
+	require.NoError(t, c.Create(context.Background(), sourceCM))
+	t.Cleanup(func() { _ = c.Delete(context.Background(), sourceCM) })
+
+	dep := newSidecarDeployment(deploymentName, testNamespace, "iag-sidecar-source-cm", 30443)
+	require.NoError(t, c.Create(context.Background(), dep))
+	t.Cleanup(func() { _ = c.Delete(context.Background(), dep) })
+	t.Cleanup(func() { cleanupSidecarResources(testNamespace, sidecarName, deploymentName) })
+
+	// Sidecar container must be injected.
+	waitForSidecarContainer(t, deploymentName, sidecarName)
+
+	var injected appsv1.Deployment
+	require.NoError(t, c.Get(context.Background(),
+		client.ObjectKey{Name: deploymentName, Namespace: testNamespace}, &injected))
+	var found bool
+	for _, ctr := range injected.Spec.Template.Spec.Containers {
+		if ctr.Name == sidecarName {
+			found = true
+		}
+	}
+	assert.True(t, found, "container %q not found in Deployment %q", sidecarName, deploymentName)
+
+	// ConfigMap with label app=<sidecarName> must exist.
+	require.Eventually(t, func() bool {
+		var cmList corev1.ConfigMapList
+		return c.List(context.Background(), &cmList,
+			client.InNamespace(testNamespace),
+			client.MatchingLabels{"app": sidecarName},
+		) == nil && len(cmList.Items) > 0
+	}, shortTimeout, pollInterval,
+		"sidecar ConfigMap with label app=%q was not created", sidecarName)
+
+	// NodePort Service with label app=<deploymentName> and nodePort 30443 must exist.
+	require.Eventually(t, func() bool {
+		var svcList corev1.ServiceList
+		if err := c.List(context.Background(), &svcList,
+			client.InNamespace(testNamespace),
+			client.MatchingLabels{"app": deploymentName},
+		); err != nil || len(svcList.Items) == 0 {
+			return false
+		}
+		for _, svc := range svcList.Items {
+			for _, p := range svc.Spec.Ports {
+				if p.NodePort == 30443 {
+					return true
+				}
+			}
+		}
+		return false
+	}, shortTimeout, pollInterval,
+		"NodePort Service with label app=%q and nodePort 30443 was not found", deploymentName)
+}
+
+// TestSidecarDeletionCleansUpResources deletes the annotated Deployment and
+// asserts that the webhook removes the sidecar ConfigMap and Service.
+// This covers the README "Delete" operation (p.1190).
+func TestSidecarDeletionCleansUpResources(t *testing.T) {
+	ensureNamespace(t)
+	ensureServiceAccount(t)
+
+	deploymentName := "iag-sidecar-delete-test"
+	sidecarName := sidecarContainerNameFor(deploymentName)
+
+	sourceCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "iag-sidecar-del-source-cm", Namespace: testNamespace},
+		Data:       map[string]string{"config.yaml": "version: \"26.7\"\n"},
+	}
+	require.NoError(t, c.Create(context.Background(), sourceCM))
+	t.Cleanup(func() { _ = c.Delete(context.Background(), sourceCM) })
+
+	dep := newSidecarDeployment(deploymentName, testNamespace, "iag-sidecar-del-source-cm", 30443)
+	require.NoError(t, c.Create(context.Background(), dep))
+	// No Cleanup for dep itself — deletion is the action under test.
+
+	// Wait for the sidecar resources to be created before deleting the Deployment.
+	waitForSidecarContainer(t, deploymentName, sidecarName)
+	require.Eventually(t, func() bool {
+		var cmList corev1.ConfigMapList
+		return c.List(context.Background(), &cmList,
+			client.InNamespace(testNamespace),
+			client.MatchingLabels{"app": sidecarName},
+		) == nil && len(cmList.Items) > 0
+	}, shortTimeout, pollInterval,
+		"sidecar ConfigMap should exist before deletion test")
+
+	// Delete the Deployment — this triggers the webhook delete handler.
+	require.NoError(t, c.Delete(context.Background(), dep))
+
+	// The sidecar ConfigMap must disappear.
+	require.Eventually(t, func() bool {
+		var cmList corev1.ConfigMapList
+		if err := c.List(context.Background(), &cmList,
+			client.InNamespace(testNamespace),
+			client.MatchingLabels{"app": sidecarName},
+		); err != nil {
+			return false
+		}
+		return len(cmList.Items) == 0
+	}, shortTimeout, pollInterval,
+		"sidecar ConfigMap with label app=%q should be deleted after Deployment deletion", sidecarName)
+
+	// The Service must also disappear.
+	require.Eventually(t, func() bool {
+		var svcList corev1.ServiceList
+		if err := c.List(context.Background(), &svcList,
+			client.InNamespace(testNamespace),
+			client.MatchingLabels{"app": deploymentName},
+		); err != nil {
+			return false
+		}
+		return len(svcList.Items) == 0
+	}, shortTimeout, pollInterval,
+		"sidecar Service with label app=%q should be deleted after Deployment deletion", deploymentName)
+
+	// The Deployment itself must also be gone.
+	require.Eventually(t, func() bool {
+		var d appsv1.Deployment
+		err := c.Get(context.Background(),
+			client.ObjectKey{Name: deploymentName, Namespace: testNamespace}, &d)
+		return errors.IsNotFound(err)
+	}, shortTimeout, pollInterval,
+		"Deployment %q should be gone", deploymentName)
+}

--- a/test/e2e/status_test.go
+++ b/test/e2e/status_test.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright contributors to the IBM Application Gateway Operator project
+ */
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	ibmv1 "github.com/ibm-security/ibm-application-gateway-operator/api/v1"
+)
+
+// TestCRStatusFalseOnBadConfigMap creates an IBMApplicationGateway CR that
+// references a ConfigMap which does not exist. The controller's manageError()
+// path sets Status.Status = false. This test asserts that the status subresource
+// is written correctly when reconcile fails.
+func TestCRStatusFalseOnBadConfigMap(t *testing.T) {
+	ensureNamespace(t)
+
+	crName := "iag-bad-cm-test"
+	cr := &ibmv1.IBMApplicationGateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      crName,
+			Namespace: testNamespace,
+		},
+		Spec: ibmv1.IBMApplicationGatewaySpec{
+			Replicas: 1,
+			Deployment: ibmv1.IBMApplicationGatewayDeployment{
+				ImageLocation:   iagImage,
+				ImagePullPolicy: "IfNotPresent",
+				Lang:            "C",
+			},
+			// Reference a ConfigMap that does not exist — reconcile must fail.
+			Configuration: []ibmv1.IBMApplicationGatewayConfiguration{
+				{
+					Type:    "configmap",
+					Name:    "nonexistent-configmap-xyz",
+					DataKey: "config.yaml",
+				},
+			},
+		},
+	}
+	require.NoError(t, c.Create(context.Background(), cr))
+	t.Cleanup(func() { _ = c.Delete(context.Background(), cr) })
+
+	// Wait for the controller to attempt reconciliation and set Status.Status = false.
+	require.Eventually(t, func() bool {
+		var latest ibmv1.IBMApplicationGateway
+		if err := c.Get(context.Background(),
+			client.ObjectKey{Name: crName, Namespace: testNamespace}, &latest); err != nil {
+			return false
+		}
+		return !latest.Status.Status
+	}, shortTimeout, pollInterval,
+		"CR %q Status.Status should become false after failed reconcile", crName)
+
+	var latest ibmv1.IBMApplicationGateway
+	require.NoError(t, c.Get(context.Background(),
+		client.ObjectKey{Name: crName, Namespace: testNamespace}, &latest))
+	assert.False(t, latest.Status.Status,
+		"CR Status.Status must be false when the referenced ConfigMap does not exist")
+}

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright contributors to the IBM Application Gateway Operator project
+ */
+
+package e2e
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	ibmv1 "github.com/ibm-security/ibm-application-gateway-operator/api/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+var (
+	c             client.Client
+	testNamespace string
+	operatorNS    string
+	iagImage      string
+	iagAltImage   string
+)
+
+func TestMain(m *testing.M) {
+	flag.StringVar(&testNamespace, "test-namespace", "ivia-e2e", "namespace for test CRs")
+	flag.StringVar(&operatorNS, "namespace", "operators", "namespace the operator is installed in")
+	flag.StringVar(&iagImage, "iag-image",
+		"icr.io/ibmappgateway/ibm-application-gateway:latest",
+		"IAG container image used in test CRs")
+	flag.StringVar(&iagAltImage, "iag-alt-image",
+		"icr.io/ibmappgateway/ibm-application-gateway:26.6.0",
+		"alternative IAG image used by image-change tests")
+	flag.Parse()
+
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = ibmv1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	_ = networkingv1.AddToScheme(scheme)
+
+	cfg, err := config.GetConfig()
+	if err != nil {
+		panic("cannot get kubeconfig: " + err.Error())
+	}
+
+	c, err = client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		panic("cannot create client: " + err.Error())
+	}
+
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
Three defects found after the v26.7.0 release, two of which surfaced during OperatorHub community operator validation:

- **CRD validation rejected `literal`-type CRs** — `url` and `discoveryEndpoint` lacked `omitempty`, so empty strings were validated against `^https://`. Fixed by adding `omitempty` to both json tags.
- **Sidecar webhook could not create Services** — the manager ClusterRole was missing `services` in the core API group. Fixed by adding the `+kubebuilder:rbac` marker and regenerating the role.
- **Manual NetworkPolicy apply failed** — the manifest contained `namespace: system` (a kustomize placeholder), causing `kubectl apply -n` to reject it. Fixed by removing the field. This step is required for OLM/OperatorHub installs since OLM rejects `NetworkPolicy` objects in bundle manifests and the policy must be applied manually post-install.

Also adds a typed Go e2e test suite (`test/e2e/`) and a GitHub Actions workflow with three jobs: `unit` (envtest, no cluster), `e2e` (kind + operator), and `e2e-sidecar` (kind + cert-manager). No log scraping — all assertions are on Kubernetes object state.
